### PR TITLE
Update to zig master

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.1.0",
     .dependencies = .{
         .tres = .{
-            .url = "https://github.com/ziglibs/tres/archive/220d01f3931595e3a2e2a6a0693363c0bfaf47e9.tar.gz",
-            .hash = "12204d32c44b494c0cbe553811dedfb7a73da37b13b492872dd4edc0340983072697",
+            .url = "https://github.com/ziglibs/tres/archive/9ca9cd547d10d30984565399dec92068fefd7ad2.tar.gz",
+            .hash = "122026823fb890736435cb5ddbfdf5691d4b9d4759ab1147f245beced0abec17c483",
         },
     },
 }

--- a/src/zig_lsp.zig
+++ b/src/zig_lsp.zig
@@ -66,15 +66,15 @@ pub fn RequestCallback(
         pub fn store(self: Self) StoredCallback {
             return .{
                 .method = method,
-                .onResponse = @ptrCast(*const fn () void, self.onResponse),
-                .onError = @ptrCast(*const fn () void, self.onError),
+                .onResponse = @ptrCast(self.onResponse),
+                .onError = @ptrCast(self.onError),
             };
         }
 
         pub fn unstore(stored: StoredCallback) Self {
             return .{
-                .onResponse = @ptrCast(OnResponse, stored.onResponse),
-                .onError = @ptrCast(OnError, stored.onError),
+                .onResponse = @ptrCast(stored.onResponse),
+                .onError = @ptrCast(stored.onError),
             };
         }
     };
@@ -165,7 +165,7 @@ pub fn Connection(
                 @compileError("Cannot send notification as request");
 
             if (@hasDecl(ContextType, "lspSendPre"))
-                try ContextType.lspSendPre(conn, method, .request, .{ .integer = @intCast(i64, conn.id) }, params);
+                try ContextType.lspSendPre(conn, method, .request, .{ .integer = @intCast(conn.id) }, params);
 
             try conn.send(.{
                 .jsonrpc = "2.0",
@@ -179,7 +179,7 @@ pub fn Connection(
             conn.id +%= 1;
 
             if (@hasDecl(ContextType, "lspSendPost"))
-                try ContextType.lspSendPost(conn, method, .request, .{ .integer = @intCast(i64, conn.id -% 1) }, params);
+                try ContextType.lspSendPost(conn, method, .request, .{ .integer = @intCast(conn.id -% 1) }, params);
         }
 
         pub fn requestSync(
@@ -193,7 +193,7 @@ pub fn Connection(
 
             const cb = struct {
                 pub fn res(conn_: *Self, result: Result(method)) !void {
-                    @ptrCast(*Result(method), @alignCast(@alignOf(Result(method)), conn_._resdata)).* = result;
+                    @as(*Result(method), @ptrCast(@alignCast(conn_._resdata))).* = result;
                 }
 
                 pub fn err(_: *Self, resperr: types.ResponseError) !void {

--- a/src/zig_lsp.zig
+++ b/src/zig_lsp.zig
@@ -198,13 +198,13 @@ pub fn Connection(
 
                 pub fn err(_: *Self, resperr: types.ResponseError) !void {
                     return switch (resperr.code) {
-                        @enumToInt(types.ErrorCodes.ParseError) => error.ParseError,
-                        @enumToInt(types.ErrorCodes.InvalidRequest) => error.InvalidRequest,
-                        @enumToInt(types.ErrorCodes.MethodNotFound) => error.MethodNotFound,
-                        @enumToInt(types.ErrorCodes.InvalidParams) => error.InvalidParams,
-                        @enumToInt(types.ErrorCodes.InternalError) => error.InternalError,
-                        @enumToInt(types.ErrorCodes.ServerNotInitialized) => error.ServerNotInitialized,
-                        @enumToInt(types.ErrorCodes.UnknownErrorCode) => error.UnknownErrorCode,
+                        @intFromEnum(types.ErrorCodes.ParseError) => error.ParseError,
+                        @intFromEnum(types.ErrorCodes.InvalidRequest) => error.InvalidRequest,
+                        @intFromEnum(types.ErrorCodes.MethodNotFound) => error.MethodNotFound,
+                        @intFromEnum(types.ErrorCodes.InvalidParams) => error.InvalidParams,
+                        @intFromEnum(types.ErrorCodes.InternalError) => error.InternalError,
+                        @intFromEnum(types.ErrorCodes.ServerNotInitialized) => error.ServerNotInitialized,
+                        @intFromEnum(types.ErrorCodes.UnknownErrorCode) => error.UnknownErrorCode,
                         else => error.InternalError,
                     };
                 }
@@ -264,7 +264,7 @@ pub fn Connection(
                 .jsonrpc = "2.0",
                 .id = id,
                 .@"error" = types.ResponseError{
-                    .code = @enumToInt(error_code),
+                    .code = @intFromEnum(error_code),
                     .message = if (error_return_trace) |ert|
                         try std.fmt.allocPrint(arena, "{s}: {any}", .{ @errorName(err), ert })
                     else


### PR DESCRIPTION
This PR makes it possible to compile the repo using the new version of the zig compiler. Builtins in the form xToY were changed to the form yFromX, the type parameter was removed from cast builtins. The deprecated JSON API was removed and exchanged for the new one.

I used the leaky version of the parseFromSlice function in the new API because the allocator seemed to be an arena, is this always the case? There does not seem to be anything enforcing this but maybe I'm missing something, I'm not too familiar with the codebase.

This PR also depends on the this PR in the tres repo: 
- [x] https://github.com/ziglibs/tres/pull/15 